### PR TITLE
Removed english_words dependency from pubspec.yaml

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,6 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^0.1.0
-  english_words: ^3.1.0
   sqflite: any
   url_launcher : ^4.0.0
   path_provider: ^0.4.1


### PR DESCRIPTION
Hi. I removed the `english_words` dependency from the `pubspec.yaml` file since it wasn't used anywhere.