### PR TITLE
Updated deprecated usages, removed unwanted imports, fixed typos.

### DIFF
--- a/lib/pages/labels/label_widget.dart
+++ b/lib/pages/labels/label_widget.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_app/bloc/bloc_provider.dart';
 import 'package:flutter_app/pages/tasks/bloc/task_bloc.dart';

--- a/lib/pages/projects/project_widget.dart
+++ b/lib/pages/projects/project_widget.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:flutter/material.dart';
 import 'package:flutter_app/bloc/bloc_provider.dart';
 import 'package:flutter_app/pages/home/home_bloc.dart';

--- a/lib/pages/tasks/bloc/add_task_bloc.dart
+++ b/lib/pages/tasks/bloc/add_task_bloc.dart
@@ -9,7 +9,6 @@ import 'package:flutter_app/pages/projects/project_db.dart';
 import 'package:flutter_app/pages/tasks/models/tasks.dart';
 import 'package:flutter_app/pages/tasks/task_db.dart';
 import 'package:rxdart/rxdart.dart';
-import 'package:rxdart/subjects.dart';
 
 class AddTaskBloc implements BlocBase {
   final TaskDB _taskDB;

--- a/lib/pages/tasks/bloc/task_bloc.dart
+++ b/lib/pages/tasks/bloc/task_bloc.dart
@@ -117,23 +117,23 @@ class TaskBloc implements BlocBase {
 
   void refresh() {
     switch (_lastFilterStatus.filterStatus!) {
-      case FILTER_STATUS.BY_TODAY:
+      case FilterStatus.BY_TODAY:
         filterTodayTasks();
         break;
 
-      case FILTER_STATUS.BY_WEEK:
+      case FilterStatus.BY_WEEK:
         filterTasksForNextWeek();
         break;
 
-      case FILTER_STATUS.BY_LABEL:
+      case FilterStatus.BY_LABEL:
         filterByLabel(_lastFilterStatus.labelName!);
         break;
 
-      case FILTER_STATUS.BY_PROJECT:
+      case FilterStatus.BY_PROJECT:
         filterByProject(_lastFilterStatus.projectId!);
         break;
 
-      case FILTER_STATUS.BY_STATUS:
+      case FilterStatus.BY_STATUS:
         filterByStatus(_lastFilterStatus.status!);
         break;
     }
@@ -145,32 +145,32 @@ class TaskBloc implements BlocBase {
   }
 }
 
-enum FILTER_STATUS { BY_TODAY, BY_WEEK, BY_PROJECT, BY_LABEL, BY_STATUS }
+enum FilterStatus { BY_TODAY, BY_WEEK, BY_PROJECT, BY_LABEL, BY_STATUS }
 
 class Filter {
   String? labelName;
   int? projectId;
-  FILTER_STATUS? filterStatus;
+  FilterStatus? filterStatus;
   TaskStatus? status;
 
   Filter.byToday() {
-    filterStatus = FILTER_STATUS.BY_TODAY;
+    filterStatus = FilterStatus.BY_TODAY;
   }
 
   Filter.byNextWeek() {
-    filterStatus = FILTER_STATUS.BY_WEEK;
+    filterStatus = FilterStatus.BY_WEEK;
   }
 
   Filter.byProject(this.projectId) {
-    filterStatus = FILTER_STATUS.BY_PROJECT;
+    filterStatus = FilterStatus.BY_PROJECT;
   }
 
   Filter.byLabel(this.labelName) {
-    filterStatus = FILTER_STATUS.BY_LABEL;
+    filterStatus = FilterStatus.BY_LABEL;
   }
 
   Filter.byStatus(this.status) {
-    filterStatus = FILTER_STATUS.BY_STATUS;
+    filterStatus = FilterStatus.BY_STATUS;
   }
 
   bool operator ==(o) =>

--- a/lib/pages/tasks/row_task.dart
+++ b/lib/pages/tasks/row_task.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_app/pages/tasks/models/tasks.dart';
 import 'package:flutter_app/utils/color_utils.dart';
@@ -7,7 +6,7 @@ import 'package:flutter_app/utils/app_constant.dart';
 
 class TaskRow extends StatelessWidget {
   final Tasks tasks;
-  static final date_label = "Date";
+  static final dateLabel = "Date";
   final List<String> labelNames = [];
 
   TaskRow(this.tasks);

--- a/lib/pages/tasks/task_completed/row_task_completed.dart
+++ b/lib/pages/tasks/task_completed/row_task_completed.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_app/pages/tasks/models/tasks.dart';
 import 'package:flutter_app/utils/color_utils.dart';
@@ -7,7 +6,7 @@ import 'package:flutter_app/utils/app_constant.dart';
 
 class TaskCompletedRow extends StatelessWidget {
   final Tasks tasks;
-  static final date_label = "Date";
+  static final dateLabel = "Date";
   final List<String> labelNames = [];
 
   TaskCompletedRow(this.tasks);
@@ -55,7 +54,7 @@ class TaskCompletedRow extends StatelessWidget {
                           getFormattedDate(tasks.dueDate),
                           style: TextStyle(
                               color: Colors.grey, fontSize: FONT_SIZE_DATE),
-                          key: Key(date_label),
+                          key: Key(dateLabel),
                         ),
                         Expanded(
                           child: Column(

--- a/lib/utils/app_util.dart
+++ b/lib/utils/app_util.dart
@@ -12,8 +12,8 @@ showSnackbar(context, String message, {MaterialColor? materialColor}) {
 
 launchURL(String url) async {
   if (url.isEmpty) return;
-  if (await canLaunch(url)) {
-    await launch(url);
+  if (await canLaunchUrl(Uri.parse(url))) {
+    await launchUrl(Uri.parse(url));
   } else {
     throw 'Could not launch $url';
   }

--- a/lib/utils/collapsable_expand_tile.dart
+++ b/lib/utils/collapsable_expand_tile.dart
@@ -11,10 +11,10 @@ class CollapsibleExpansionTile extends StatefulWidget {
     required this.title,
     this.backgroundColor,
     this.onExpansionChanged,
-    this.children: const <Widget>[],
+    this.children = const <Widget>[],
     this.trailing,
-    this.initiallyExpanded: false,
-  })  : super(key: key);
+    this.initiallyExpanded = false,
+  }) : super(key: key);
 
   final Widget? leading;
   final Widget title;
@@ -53,8 +53,7 @@ class CollapsibleExpansionTileState extends State<CollapsibleExpansionTile>
     _borderColor = ColorTween();
     _headerColor = ColorTween();
     _iconColor = ColorTween();
-    _iconTurns =
-        Tween<double>(begin: 0.0, end: 0.5).animate(_easeInAnimation);
+    _iconTurns = Tween<double>(begin: 0.0, end: 0.5).animate(_easeInAnimation);
     _backgroundColor = ColorTween();
 
     _isExpanded =
@@ -117,16 +116,14 @@ class CollapsibleExpansionTileState extends State<CollapsibleExpansionTile>
         mainAxisSize: MainAxisSize.min,
         children: <Widget>[
           IconTheme.merge(
-            data:
-                IconThemeData(color: _iconColor.evaluate(_easeInAnimation)),
+            data: IconThemeData(color: _iconColor.evaluate(_easeInAnimation)),
             child: ListTile(
               onTap: toggle,
               leading: widget.leading,
               title: DefaultTextStyle(
-                style: Theme
-                    .of(context)
+                style: Theme.of(context)
                     .textTheme
-                    .subtitle1!
+                    .titleMedium!
                     .copyWith(color: titleColor),
                 child: widget.title,
               ),
@@ -153,11 +150,11 @@ class CollapsibleExpansionTileState extends State<CollapsibleExpansionTile>
     final ThemeData theme = Theme.of(context);
     _borderColor.end = theme.dividerColor;
     _headerColor
-      ..begin = theme.textTheme.subtitle1!.color
-      ..end = theme.accentColor;
+      ..begin = theme.textTheme.titleMedium!.color
+      ..end = theme.colorScheme.secondary;
     _iconColor
       ..begin = theme.unselectedWidgetColor
-      ..end = theme.accentColor;
+      ..end = theme.colorScheme.secondary;
     _backgroundColor.end = widget.backgroundColor;
 
     final bool closed = !_isExpanded && _controller.isDismissed;

--- a/lib/utils/extension.dart
+++ b/lib/utils/extension.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/widgets.dart';
 import 'package:flutter_app/bloc/bloc_provider.dart';
 import 'package:flutter_app/pages/home/home_bloc.dart';
 

--- a/test/test_helpers.dart
+++ b/test/test_helpers.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/widgets.dart';
 import 'package:flutter_app/bloc/bloc_provider.dart';
 import 'package:flutter_app/pages/home/home_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';


### PR DESCRIPTION
**Changes Made**
- [x] Updated deprecated code
```diff
-Theme.of(context).textTheme.subtitle1!.copyWith(color: titleColor),
+Theme.of(context).textTheme.titleMedium!.copyWith(color: titleColor),

-if (await canLaunch(url)) {
-    await launch(url);
-  }
+if (await canLaunchUrl(Uri.parse(url))) {
+   await launchUrl(Uri.parse(url));
+  } 

-theme.accentColor;
+theme.colorScheme.secondary;
```

- [x] Typo fixes
- dart prefers UpperCase words for enums and lowerCase words for variables.
- For constructor variable assignment, dart prefers `=` rather than `:`
```diff
-FILTER_STATUS  
+FilterStatus

-date_label
+dateLabel
```
- [x] Removed unwanted imports from the files.