### PR TITLE
Url launch error fixed.

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -7,6 +7,18 @@
   -->
   <uses-permission android:name="android.permission.INTERNET"/>
 
+  <queries>
+    <intent>
+      <action android:name="android.intent.action.VIEW" />
+      <data android:scheme="https" />
+    </intent>
+
+    <intent>
+      <action android:name="android.intent.action.VIEW" />
+      <data android:scheme="mailto"/>
+    </intent>
+  </queries>
+
   <!-- io.flutter.app.FlutterApplication is an android.app.Application that
        calls FlutterMain.startInitialization(this); in its onCreate method.
        In most cases you can leave this as-is, but you if you want to provide

--- a/lib/utils/app_util.dart
+++ b/lib/utils/app_util.dart
@@ -13,7 +13,10 @@ showSnackbar(context, String message, {MaterialColor? materialColor}) {
 launchURL(String url) async {
   if (url.isEmpty) return;
   if (await canLaunchUrl(Uri.parse(url))) {
-    await launchUrl(Uri.parse(url));
+    await launchUrl(
+      Uri.parse(url),
+      mode: LaunchMode.externalApplication,
+    );
   } else {
     throw 'Could not launch $url';
   }


### PR DESCRIPTION
Issue:
- canLaunchUrl() func always return false unless `<queries>` element for the scheme is added.
[refer](https://pub.dev/packages/url_launcher#configuration)
- Due to this no link in the **About** page was getting launched.

Fixes:
1. So added required <queries> tags in the manifest file.
1. Also launch mode was set to `LaunchMode.externalApplication` in order to get rid of the webview launch.