### PR TITLE
downscale the Facebook logo in about page

### DIFF
--- a/lib/pages/about/about_us.dart
+++ b/lib/pages/about/about_us.dart
@@ -107,7 +107,10 @@ class AboutUsScreen extends StatelessWidget {
                             onPressed: () => launchURL(TWITTER_URL),
                           ),
                           IconButton(
-                            icon: Image.asset("assets/facebook_logo.png"),
+                            icon: Image.asset(
+                              "assets/facebook_logo.png",
+                              scale: 14.25,
+                            ),
                             onPressed: () => launchURL(FACEBOOK_URL),
                           )
                         ],


### PR DESCRIPTION
Currently the Facebook logo is too big.
![image](https://github.com/user-attachments/assets/56ad483e-58bc-49a5-a194-b73d5dc46be4)

It should be downscaled like this:
![image](https://github.com/user-attachments/assets/5925ceae-20d1-47c7-93d4-2a6749fda916)
